### PR TITLE
Update lightstep-tracer-java submodule

### DIFF
--- a/benchlib/bench.go
+++ b/benchlib/bench.go
@@ -65,7 +65,6 @@ type Control struct {
 	// Misc control bits
 	Trace   bool // Trace the operation.
 	Exit    bool // Terminate the test.
-	Profile bool // Profile this operation
 }
 
 type Result struct {

--- a/scripts/docker/Dockerfile.java
+++ b/scripts/docker/Dockerfile.java
@@ -8,6 +8,5 @@ RUN apt-get update && \
 
 COPY controller /data
 COPY lightstep-benchmark.jar /data
-COPY lightstep-tracer-jre.jar /data
 
-ENV CLASSPATH /data/lightstep-tracer-jre.jar:/data/lightstep-benchmark.jar
+ENV CLASSPATH /data/lightstep-benchmark.jar

--- a/scripts/docker/java.sh
+++ b/scripts/docker/java.sh
@@ -3,10 +3,10 @@
 set -e
 
 JAVA=${CLIENTS_DIR}/lightstep-tracer-java
-JRE=${JAVA}/lightstep-tracer-jre
-VERSION=`awk 'BEGIN { FS = "=" }; { printf("%s", $2) }' ${JAVA}/gradle.properties`
+BENCHMARK=${JAVA}/benchmark
 
-(cd ${JAVA} && ./gradlew -b build.gradle build)
+cd ${JAVA}
+make build
+VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`
 
-ln ${JRE}/build/libs/lightstep-benchmark-${VERSION}.jar ${DBUILD}/lightstep-benchmark.jar
-ln ${JRE}/build/libs/lightstep-tracer-jre-${VERSION}.jar ${DBUILD}/lightstep-tracer-jre.jar
+ln ${BENCHMARK}/target/benchmark-${VERSION}.jar ${DBUILD}/lightstep-benchmark.jar


### PR DESCRIPTION
The latest repo now provides an uber jar in the benchmark module so this necessitated updating some of the launch scripts as well.

LS-1147